### PR TITLE
add CLI support

### DIFF
--- a/bin/diacritics
+++ b/bin/diacritics
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+var remove = require('../index.js').remove
+
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('readable', function() {
+  var chunk = process.stdin.read();
+    if (chunk !== null) {
+      process.stdout.write(remove(chunk));
+    }
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "search",
     "string"
   ],
+  "bin": {
+    "diacritics": "bin/diacritics"
+  },
   "author": "Andrew Kelley",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Hi,

A friend of mine who is not a programmer needed your tool for his work, so I interfaced it to STDIN

This patcj enables you to do install the package globally and do stuff like:

Boriss-MacBook-Air:node-diacritics borismarinov$ echo "aIлｔèｒｎåｔｏｎɑｌíƶa" | diacritics
aInternatonaliza
