### PR TITLE
Export replacementList and diacriticsMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,3 +311,6 @@ function removeDiacritics(str) {
     return diacriticsMap[c] || c;
   });
 }
+
+exports.replacementList = replacementList;
+exports.diacriticsMap = diacriticsMap;


### PR DESCRIPTION
Make `replacementList` and `diacriticsMap` available. 

I developed a npm module [srch](https://www.npmjs.com/package/srch) in which I also handle [diacritics](https://github.com/paperhive/srch/pull/9). In addition to a string without diacritics I determine the mapping between the original and the transformed string. For the latter issue I just need the raw list/map. I would be very happy if you could merge this addition.

Note: This was also requested in https://github.com/andrewrk/node-diacritics/issues/20.