### PR TITLE
Adding new characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,14 @@ exports.remove = removeDiacritics;
 
 var replacementList = [
   {
+    base: '',
+    chars: "\u200B",
+  }, {
     base: ' ',
     chars: "\u00A0",
+  }, { 
+    base: '"',
+    chars: "\u201C\u201D\uFF02",
   }, {
     base: '0',
     chars: "\u07C0",

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ var replacementList = [
   }, {
     base: ' ',
     chars: "\u00A0",
+  }, {
+	base: "'",
+	chars: "\u2019\u2018",
   }, { 
     base: '"',
     chars: "\u201C\u201D\uFF02",

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ var replacementList = [
     base: ' ',
     chars: "\u00A0",
   }, {
-	base: "'",
-	chars: "\u2019\u2018",
+    base: "'",
+    chars: "\u2019\u2018",
   }, { 
     base: '"',
     chars: "\u201C\u201D\uFF02",


### PR DESCRIPTION
1. All single and double quotation marks that chrome’s search feature recognises: 
- Shown by searching here https://unicode-table.com/en/sets/quotation-marks/
- An example of these quotes being used is in the title at the top of this page https://stackoverflow.com/questions/12988140/what-is-the-difference-between-and-1-operators

2. Zero-width spaces:
- Text editors like 'SunEditor' add these. Other examples here https://stackoverflow.com/questions/9868796/how-to-display-hidden-characters-by-default-zero-width-space-ie-8203.
- Likewise, chrome’s search feature also matches these, as shown by searching in the two text examples here https://en.wikipedia.org/wiki/Zero-width_space